### PR TITLE
Refactor GUI widgets

### DIFF
--- a/control/python_pc/gui/main_window.py
+++ b/control/python_pc/gui/main_window.py
@@ -13,212 +13,31 @@ import math
 import importlib
 import multiprocessing
 from PyQt5.QtWidgets import (
-    QApplication, QWidget, QVBoxLayout, QHBoxLayout, QPushButton, QComboBox, QCheckBox,
-    QLabel, QLineEdit, QFormLayout, QGroupBox, QSpinBox, QDoubleSpinBox, QListWidget,
-    QListWidgetItem, QAbstractItemView, QFrame
+    QApplication,
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QPushButton,
+    QComboBox,
+    QCheckBox,
+    QLabel,
+    QLineEdit,
+    QFormLayout,
+    QGroupBox,
+    QSpinBox,
+    QDoubleSpinBox,
+    QListWidget,
+    QListWidgetItem,
+    QAbstractItemView,
 )
-from PyQt5.QtGui import QPainter, QPen, QBrush, QColor
-from PyQt5.QtCore import Qt, QTimer, QEvent, QPointF, QRectF
-import pyqtgraph as pg
+from PyQt5.QtCore import Qt, QTimer, QEvent
+
+from .visualizer import PendulumVisualizer
+from .plot_widgets import PlotContainer, PlotList, DropPlotArea
 
 from backends.linear_sim_backend import start_linear_simulation_backend
 from backends.nonlinear_sim_backend import start_nonlinear_simulation_backend
 
-class PendulumVisualizer(QWidget):
-    def __init__(self, shared_vars=None):
-        super().__init__()
-        self.shared_vars = shared_vars  # Set once at initialization
-        self.cart_width = 50
-        self.cart_height = 20
-        self.pendulum_length = 80
-        self.setMinimumSize(400, 200)
-        
-        # Visual styling
-        self.track_color = QColor(100, 100, 100)
-        self.cart_color = QColor(70, 130, 180)  # Steel blue
-        self.pendulum_color = QColor(220, 220, 220)  # Light gray
-        self.bob_color = QColor(200, 50, 50)  # Red
-        
-    def paintEvent(self, event):
-        painter = QPainter(self)
-        painter.setRenderHint(QPainter.Antialiasing)
-        
-        if not self.shared_vars:
-            # Draw placeholder when no data
-            painter.drawText(self.rect(), Qt.AlignCenter, "No pendulum data")
-            return
-            
-        try:
-            # Get current values (safe access)
-            x_pos = self.shared_vars["position"].value
-            angle = self.shared_vars["angle"].value
-        except (KeyError, AttributeError):
-            return
-            
-        width = self.width()
-        height = self.height()
-        center_y = height // 2
-        
-        # Scale x position (1 meter = 100 pixels)
-        x_scaled = width // 2 + x_pos * 500
-        
-        # Draw track
-        painter.setPen(QPen(self.track_color, 2))
-        track_y = center_y + self.cart_height//2 + 5
-        painter.drawLine(0, track_y, width, track_y)
-        
-        # Draw cart
-        cart_rect = QRectF(
-            x_scaled - self.cart_width//2,
-            center_y - self.cart_height//2,
-            self.cart_width,
-            self.cart_height
-        )
-        painter.setBrush(QBrush(self.cart_color))
-        painter.setPen(QPen(Qt.black, 1))
-        painter.drawRect(cart_rect)
-        
-        # Draw pendulum
-        pivot = QPointF(x_scaled, center_y)
-        end_x = pivot.x() + self.pendulum_length * math.sin(angle)
-        end_y = pivot.y() + self.pendulum_length * math.cos(angle)
-        
-        painter.setPen(QPen(self.pendulum_color, 3))
-        painter.drawLine(pivot, QPointF(end_x, end_y))
-        
-        # Draw pendulum bob
-        painter.setBrush(QBrush(self.bob_color))
-        painter.drawEllipse(QPointF(end_x, end_y), 10, 10)
-
-class PlotContainer(pg.GraphicsLayoutWidget):
-    def __init__(self, plot_name, y_range, getter):
-        super().__init__()
-        self.plot_name = plot_name
-        self.getter = getter
-        self.data = [0] * 200
-        self.max_points = 200
-        self.plot_item = self.addPlot(title=plot_name)
-        self.plot_item.showGrid(x=True, y=True)
-        self.plot_item.setYRange(*y_range)
-        self.curve = self.plot_item.plot(pen=pg.mkPen(color='y', width=2))
-
-    def update_plot(self, shared_vars):
-        value = self.getter(shared_vars)
-        self.data.append(value)
-        if len(self.data) > self.max_points:
-            self.data.pop(0)
-        self.curve.setData(self.data)
-
-class PlotList(QListWidget):
-    def __init__(self, drop_area):
-        super().__init__()
-        self.drop_area = drop_area
-        self.setSelectionMode(QAbstractItemView.SingleSelection)
-        self.setFrameShape(QFrame.StyledPanel)
-
-        # Add control buttons below the list
-        self.button_layout = QVBoxLayout()
-
-        self.add_button = QPushButton("Add")
-        self.add_button.clicked.connect(self.add_selected_plot)
-        self.button_layout.addWidget(self.add_button)
-
-        self.remove_button = QPushButton("Remove")
-        self.remove_button.clicked.connect(self.remove_selected_plot)
-        self.button_layout.addWidget(self.remove_button)
-
-        self.up_button = QPushButton("Move Up")
-        self.up_button.clicked.connect(self.move_plot_up)
-        self.button_layout.addWidget(self.up_button)
-
-        self.down_button = QPushButton("Move Down")
-        self.down_button.clicked.connect(self.move_plot_down)
-        self.button_layout.addWidget(self.down_button)
-
-        self.button_container = QWidget()
-        self.button_container.setLayout(self.button_layout)
-
-        # Disable editing or dragging
-        self.setEditTriggers(QAbstractItemView.NoEditTriggers)
-        self.setDragDropMode(QAbstractItemView.NoDragDrop)
-
-    def populate(self, plot_names):
-        self.clear()
-        for name in plot_names:
-            self.addItem(name)
-
-    def get_selected_plot_name(self):
-        item = self.currentItem()
-        return item.text() if item else None
-
-    def add_selected_plot(self):
-        plot_name = self.get_selected_plot_name()
-        if plot_name and plot_name not in self.drop_area.active_plot_widgets:
-            key, y_range, getter = self.drop_area.available_plots[plot_name]
-            plot_widget = PlotContainer(plot_name, y_range, getter)
-            self.drop_area.layout.addWidget(plot_widget)
-            self.drop_area.active_plot_widgets[plot_name] = plot_widget
-
-    def remove_selected_plot(self):
-        plot_name = self.get_selected_plot_name()
-        if plot_name:
-            self.drop_area.remove_plot(plot_name)
-
-    def move_plot_up(self):
-        plot_name = self.get_selected_plot_name()
-        if plot_name and plot_name in self.drop_area.active_plot_widgets:
-            widgets = self.drop_area.active_plot_widgets
-            names = list(widgets.keys())
-            idx = names.index(plot_name)
-            if idx > 0:
-                names[idx], names[idx - 1] = names[idx - 1], names[idx]
-                self._reorder_plots(names)
-
-    def move_plot_down(self):
-        plot_name = self.get_selected_plot_name()
-        if plot_name and plot_name in self.drop_area.active_plot_widgets:
-            widgets = self.drop_area.active_plot_widgets
-            names = list(widgets.keys())
-            idx = names.index(plot_name)
-            if idx < len(names) - 1:
-                names[idx], names[idx + 1] = names[idx + 1], names[idx]
-                self._reorder_plots(names)
-
-    def _reorder_plots(self, ordered_names):
-        for i in reversed(range(self.drop_area.layout.count())):
-            item = self.drop_area.layout.itemAt(i)
-            widget = item.widget()
-            if widget:
-                self.drop_area.layout.removeWidget(widget)
-                widget.setParent(None)
-
-        new_widgets = {}
-        for name in ordered_names:
-            key, y_range, getter = self.drop_area.available_plots[name]
-            widget = PlotContainer(name, y_range, getter)
-            self.drop_area.layout.addWidget(widget)
-            new_widgets[name] = widget
-
-        self.drop_area.active_plot_widgets = new_widgets
-
-class DropPlotArea(QWidget):
-    def __init__(self, available_plots, shared_vars):
-        super().__init__()
-        self.layout = QVBoxLayout()
-        self.setLayout(self.layout)
-        self.available_plots = available_plots
-        self.shared_vars = shared_vars
-        self.active_plot_widgets = {}
-
-    def remove_plot(self, plot_name):
-        if plot_name in self.active_plot_widgets:
-            widget = self.active_plot_widgets.pop(plot_name)
-            self.layout.removeWidget(widget)
-            widget.setParent(None)
-
-    def update_all(self):
-        for widget in self.active_plot_widgets.values():
-            widget.update_plot(self.shared_vars)
 
 class MainWindow(QWidget):
     def __init__(self):

--- a/control/python_pc/gui/plot_widgets.py
+++ b/control/python_pc/gui/plot_widgets.py
@@ -1,0 +1,154 @@
+"""
+plot_widgets.py
+
+Utility widgets for plotting simulation data within the GUI.
+"""
+
+from PyQt5.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QListWidget,
+    QPushButton,
+    QAbstractItemView,
+    QFrame,
+)
+from pyqtgraph import GraphicsLayoutWidget, mkPen
+
+
+class PlotContainer(GraphicsLayoutWidget):
+    """Widget containing a single scrolling plot."""
+
+    def __init__(self, plot_name, y_range, getter):
+        super().__init__()
+        self.plot_name = plot_name
+        self.getter = getter
+        self.data = [0] * 200
+        self.max_points = 200
+        self.plot_item = self.addPlot(title=plot_name)
+        self.plot_item.showGrid(x=True, y=True)
+        self.plot_item.setYRange(*y_range)
+        self.curve = self.plot_item.plot(pen=mkPen(color="y", width=2))
+
+    def update_plot(self, shared_vars):
+        value = self.getter(shared_vars)
+        self.data.append(value)
+        if len(self.data) > self.max_points:
+            self.data.pop(0)
+        self.curve.setData(self.data)
+
+
+class PlotList(QListWidget):
+    """List widget with helpers to manage plots."""
+
+    def __init__(self, drop_area):
+        super().__init__()
+        self.drop_area = drop_area
+        self.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.setFrameShape(QFrame.StyledPanel)
+
+        # Add control buttons below the list
+        self.button_layout = QVBoxLayout()
+
+        self.add_button = QPushButton("Add")
+        self.add_button.clicked.connect(self.add_selected_plot)
+        self.button_layout.addWidget(self.add_button)
+
+        self.remove_button = QPushButton("Remove")
+        self.remove_button.clicked.connect(self.remove_selected_plot)
+        self.button_layout.addWidget(self.remove_button)
+
+        self.up_button = QPushButton("Move Up")
+        self.up_button.clicked.connect(self.move_plot_up)
+        self.button_layout.addWidget(self.up_button)
+
+        self.down_button = QPushButton("Move Down")
+        self.down_button.clicked.connect(self.move_plot_down)
+        self.button_layout.addWidget(self.down_button)
+
+        self.button_container = QWidget()
+        self.button_container.setLayout(self.button_layout)
+
+        # Disable editing or dragging
+        self.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.setDragDropMode(QAbstractItemView.NoDragDrop)
+
+    def populate(self, plot_names):
+        self.clear()
+        for name in plot_names:
+            self.addItem(name)
+
+    def get_selected_plot_name(self):
+        item = self.currentItem()
+        return item.text() if item else None
+
+    def add_selected_plot(self):
+        plot_name = self.get_selected_plot_name()
+        if plot_name and plot_name not in self.drop_area.active_plot_widgets:
+            key, y_range, getter = self.drop_area.available_plots[plot_name]
+            plot_widget = PlotContainer(plot_name, y_range, getter)
+            self.drop_area.layout.addWidget(plot_widget)
+            self.drop_area.active_plot_widgets[plot_name] = plot_widget
+
+    def remove_selected_plot(self):
+        plot_name = self.get_selected_plot_name()
+        if plot_name:
+            self.drop_area.remove_plot(plot_name)
+
+    def move_plot_up(self):
+        plot_name = self.get_selected_plot_name()
+        if plot_name and plot_name in self.drop_area.active_plot_widgets:
+            widgets = self.drop_area.active_plot_widgets
+            names = list(widgets.keys())
+            idx = names.index(plot_name)
+            if idx > 0:
+                names[idx], names[idx - 1] = names[idx - 1], names[idx]
+                self._reorder_plots(names)
+
+    def move_plot_down(self):
+        plot_name = self.get_selected_plot_name()
+        if plot_name and plot_name in self.drop_area.active_plot_widgets:
+            widgets = self.drop_area.active_plot_widgets
+            names = list(widgets.keys())
+            idx = names.index(plot_name)
+            if idx < len(names) - 1:
+                names[idx], names[idx + 1] = names[idx + 1], names[idx]
+                self._reorder_plots(names)
+
+    def _reorder_plots(self, ordered_names):
+        for i in reversed(range(self.drop_area.layout.count())):
+            item = self.drop_area.layout.itemAt(i)
+            widget = item.widget()
+            if widget:
+                self.drop_area.layout.removeWidget(widget)
+                widget.setParent(None)
+
+        new_widgets = {}
+        for name in ordered_names:
+            key, y_range, getter = self.drop_area.available_plots[name]
+            widget = PlotContainer(name, y_range, getter)
+            self.drop_area.layout.addWidget(widget)
+            new_widgets[name] = widget
+
+        self.drop_area.active_plot_widgets = new_widgets
+
+
+class DropPlotArea(QWidget):
+    """Container that holds active plot widgets."""
+
+    def __init__(self, available_plots, shared_vars):
+        super().__init__()
+        self.layout = QVBoxLayout()
+        self.setLayout(self.layout)
+        self.available_plots = available_plots
+        self.shared_vars = shared_vars
+        self.active_plot_widgets = {}
+
+    def remove_plot(self, plot_name):
+        if plot_name in self.active_plot_widgets:
+            widget = self.active_plot_widgets.pop(plot_name)
+            self.layout.removeWidget(widget)
+            widget.setParent(None)
+
+    def update_all(self):
+        for widget in self.active_plot_widgets.values():
+            widget.update_plot(self.shared_vars)

--- a/control/python_pc/gui/visualizer.py
+++ b/control/python_pc/gui/visualizer.py
@@ -1,0 +1,79 @@
+"""
+visualizer.py
+
+Widget for visualizing the cart-pendulum system state.
+"""
+
+import math
+from PyQt5.QtWidgets import QWidget
+from PyQt5.QtGui import QPainter, QPen, QBrush, QColor
+from PyQt5.QtCore import Qt, QPointF, QRectF
+
+
+class PendulumVisualizer(QWidget):
+    """Simple QWidget that draws the pendulum and cart."""
+
+    def __init__(self, shared_vars=None):
+        super().__init__()
+        self.shared_vars = shared_vars  # Set once at initialization
+        self.cart_width = 50
+        self.cart_height = 20
+        self.pendulum_length = 80
+        self.setMinimumSize(400, 200)
+
+        # Visual styling
+        self.track_color = QColor(100, 100, 100)
+        self.cart_color = QColor(70, 130, 180)  # Steel blue
+        self.pendulum_color = QColor(220, 220, 220)  # Light gray
+        self.bob_color = QColor(200, 50, 50)  # Red
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+
+        if not self.shared_vars:
+            # Draw placeholder when no data
+            painter.drawText(self.rect(), Qt.AlignCenter, "No pendulum data")
+            return
+
+        try:
+            # Get current values (safe access)
+            x_pos = self.shared_vars["position"].value
+            angle = self.shared_vars["angle"].value
+        except (KeyError, AttributeError):
+            return
+
+        width = self.width()
+        height = self.height()
+        center_y = height // 2
+
+        # Scale x position (1 meter = 100 pixels)
+        x_scaled = width // 2 + x_pos * 500
+
+        # Draw track
+        painter.setPen(QPen(self.track_color, 2))
+        track_y = center_y + self.cart_height // 2 + 5
+        painter.drawLine(0, track_y, width, track_y)
+
+        # Draw cart
+        cart_rect = QRectF(
+            x_scaled - self.cart_width // 2,
+            center_y - self.cart_height // 2,
+            self.cart_width,
+            self.cart_height,
+        )
+        painter.setBrush(QBrush(self.cart_color))
+        painter.setPen(QPen(Qt.black, 1))
+        painter.drawRect(cart_rect)
+
+        # Draw pendulum
+        pivot = QPointF(x_scaled, center_y)
+        end_x = pivot.x() + self.pendulum_length * math.sin(angle)
+        end_y = pivot.y() + self.pendulum_length * math.cos(angle)
+
+        painter.setPen(QPen(self.pendulum_color, 3))
+        painter.drawLine(pivot, QPointF(end_x, end_y))
+
+        # Draw pendulum bob
+        painter.setBrush(QBrush(self.bob_color))
+        painter.drawEllipse(QPointF(end_x, end_y), 10, 10)


### PR DESCRIPTION
## Summary
- split visualizer and plotting widgets into separate modules
- update imports in `main_window.py`
- leave `main.py` using `run_gui` from `gui.main_window`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846b74b3cd0832486909771a3ca9823