### PR TITLE
Fix GUI entrypoint

### DIFF
--- a/control/python_pc/gui/gui.py
+++ b/control/python_pc/gui/gui.py
@@ -1,8 +1,12 @@
 # gui.py
 import sys
 from PyQt5.QtWidgets import QApplication
-from main_window import MainWindow
-from utils.settings_manager import SettingsManager
+
+# Import from the current package so this module works whether executed as part
+# of the package or as a script. Absolute imports would fail when invoked via
+# ``control/python_pc/main.py`` as they would not resolve correctly.
+from .main_window import MainWindow
+from ..utils.settings_manager import SettingsManager
 
 def run_gui():
     app = QApplication(sys.argv)

--- a/control/python_pc/main.py
+++ b/control/python_pc/main.py
@@ -11,7 +11,9 @@ Author: Tom Bieber
 """
 
 import multiprocessing
-from gui import run_gui
+# ``run_gui`` lives in the ``gui`` module within the ``gui`` package. Importing
+# it explicitly from ``gui.gui`` avoids relying on package ``__init__`` exports.
+from gui.gui import run_gui
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- fix incorrect `main.py` entry point that attempted to call `run_gui` before imports
- streamline `main()` to call the `gui.gui.run_gui()` helper

## Testing
- `python3 -m py_compile control/python_pc/main.py control/python_pc/gui/gui.py control/python_pc/gui/main_window.py control/python_pc/utils/settings_manager.py`
- `python3 -m py_compile control/python_pc/**/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6846d95b56588324a0cebc5c2e911493